### PR TITLE
Use current Permissions-Policy directive for Cloudflare headers

### DIFF
--- a/src/site/_headers
+++ b/src/site/_headers
@@ -1,0 +1,2 @@
+/*
+  Permissions-Policy: browsing-topics=()


### PR DESCRIPTION
## What changed
- add a Cloudflare `_headers` file under `src/site`
- use the current `Permissions-Policy: browsing-topics=()` directive instead of the legacy `interest-cohort=()` directive

## Why
- Cloudflare Pages expects static response headers in a `_headers` file
- `browsing-topics` is the current Permissions Policy directive for opting out of Topics-related behavior

## Validation
- verified the `_headers` file format against Cloudflare Pages documentation
- did not run a full local build in this workspace because dependencies are not installed here (`npm run prod` previously failed with `vite: command not found`)
